### PR TITLE
Shell and CLI improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "alacritty/catppuccin"]
 	path = alacritty/catppuccin
 	url = https://github.com/catppuccin/alacritty
+[submodule "bat/catppuccin"]
+	path = bat/catppuccin
+	url = https://github.com/catppuccin/bat

--- a/Brewfile
+++ b/Brewfile
@@ -2,6 +2,7 @@ tap "nikitabobko/tap"
 tap "felixkratz/formulae"
 
 # CLI utilities
+brew "bat"
 brew "btop"
 brew "fd"
 brew "fzf"
@@ -12,6 +13,7 @@ brew "speedtest-cli"
 brew "tree"
 brew "watch"
 brew "wget"
+brew "zoxide"
 
 # Languages & runtimes are managed by asdf
 

--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,4 @@ check:
 	check $(CURDIR)/zsh/zprofile ${HOME}/.zprofile; \
 	check $(CURDIR)/zsh/zshrc ${HOME}/.zshrc; \
 	echo ""; echo "$$ok ok, $$fail failed"
+	@command -v brew >/dev/null && HOMEBREW_BUNDLE_NO_UPGRADE=1 brew bundle check --verbose || true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: aerospace alacritty bin brew check deps dunst font i3 linux mac mako nvim sketchybar spotify sway tmux waybar x zsh
+.PHONY: aerospace alacritty bat bin brew check deps dunst font i3 linux mac mako nvim sketchybar spotify sway tmux waybar x zsh
 
 brew:
 	brew bundle
@@ -18,6 +18,12 @@ alacritty:
 	mkdir -p ${HOME}/.config/alacritty/catppuccin
 	ln -fs $(CURDIR)/alacritty/alacritty.toml ${HOME}/.config/alacritty/alacritty.toml
 	ln -fs $(CURDIR)/alacritty/catppuccin/catppuccin-mocha.toml ${HOME}/.config/alacritty/catppuccin/catppuccin-mocha.toml
+
+bat:
+	mkdir -p ${HOME}/.config/bat
+	ln -fs $(CURDIR)/bat/config ${HOME}/.config/bat/config
+	ln -fns $(CURDIR)/bat/catppuccin/themes ${HOME}/.config/bat/themes
+	bat cache --build
 
 bin:
 	mkdir -p ${HOME}/bin
@@ -46,7 +52,7 @@ i3:
 
 linux: deps alacritty bin dunst font i3 mako nvim spotify sway tmux waybar x zsh
 
-mac: brew deps aerospace alacritty nvim sketchybar tmux zsh
+mac: brew deps aerospace alacritty bat nvim sketchybar tmux zsh
 
 mako:
 	mkdir -p ${HOME}/.config/mako
@@ -105,6 +111,8 @@ check:
 	check $(CURDIR)/aerospace/aerospace.toml ${HOME}/.aerospace.toml; \
 	check $(CURDIR)/alacritty/alacritty.toml ${HOME}/.config/alacritty/alacritty.toml; \
 	check $(CURDIR)/alacritty/catppuccin/catppuccin-mocha.toml ${HOME}/.config/alacritty/catppuccin/catppuccin-mocha.toml; \
+	check $(CURDIR)/bat/config ${HOME}/.config/bat/config; \
+	check $(CURDIR)/bat/catppuccin/themes ${HOME}/.config/bat/themes; \
 	check $(CURDIR)/nvim/lua ${HOME}/.config/nvim/lua; \
 	check $(CURDIR)/nvim/init.lua ${HOME}/.config/nvim/init.lua; \
 	check $(CURDIR)/nvim/lazy-lock.json ${HOME}/.config/nvim/lazy-lock.json; \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ brew:
 deps:
 	[ -d ${HOME}/.oh-my-zsh ] || git clone https://github.com/ohmyzsh/ohmyzsh.git ${HOME}/.oh-my-zsh
 	[ -d ${HOME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions ] || git clone https://github.com/zsh-users/zsh-autosuggestions ${HOME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+	[ -d ${HOME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting ] || git clone https://github.com/zsh-users/zsh-syntax-highlighting ${HOME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
 	[ -d ${HOME}/.tmux/plugins/tpm ] || git clone https://github.com/tmux-plugins/tpm ${HOME}/.tmux/plugins/tpm
 
 aerospace:

--- a/bat/config
+++ b/bat/config
@@ -1,0 +1,1 @@
+--theme="Catppuccin Mocha"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -18,6 +18,7 @@ set -g escape-time 0
 set -g mouse off
 set -g mode-keys vi
 set -g focus-events on
+set -g renumber-windows on
 
 # vim-like pane switching
 bind -r ^ last-window

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -50,7 +50,7 @@ COMPLETION_WAITING_DOTS="true"
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(aws git battery kubectl zsh-autosuggestions fzf kube-ps1 asdf)
+plugins=(aws git battery kubectl zsh-autosuggestions fzf kube-ps1 asdf zsh-syntax-highlighting)
 
 # User configuration
 
@@ -127,6 +127,10 @@ alias production="kubectl config use-context production"
 alias shared="kubectl config use-context shared"
 alias tf="terraform"
 alias vim="nvim"
+if command -v bat >/dev/null; then
+  alias cat="bat --paging=never"
+  export MANPAGER="sh -c 'col -bx | bat -l man -p'"
+fi
 alias finder="open ."
 cc() {
   [[ -n "$TMUX" ]] && tmux rename-window "$1"
@@ -164,6 +168,9 @@ SAVEHIST=1000000000
 setopt INC_APPEND_HISTORY
 setopt EXTENDED_HISTORY
 setopt HIST_FIND_NO_DUPS
+setopt SHARE_HISTORY
+
+command -v zoxide >/dev/null && eval "$(zoxide init zsh --cmd cd)"
 
 [ -f ~/.secrets ] && source ~/.secrets
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"


### PR DESCRIPTION
## Summary
- **tmux**: enable `renumber-windows` so window numbers stay contiguous when one closes
- **zsh**: add `zsh-syntax-highlighting` (cloned via `make deps`, loaded last in the plugin list), `SHARE_HISTORY` for live history sharing across sessions
- **zoxide**: installed via Brewfile, initialized with `--cmd cd` so `cd` gains frecency-jumping while normal paths behave unchanged (`cdi` for interactive picking)
- **bat**: installed via Brewfile; `cat` aliased to `bat --paging=never` (plain output when piped, so scripts are unaffected); `MANPAGER` set for syntax-highlighted man pages; Catppuccin Mocha theme vendored as a `catppuccin/bat` submodule with a new `make bat` target, mirroring the alacritty theme setup
- **make check**: now also runs `brew bundle check` (with `HOMEBREW_BUNDLE_NO_UPGRADE=1`, so it flags missing/unlinked formulae without failing on merely-outdated ones)

## Test plan
- [x] `make check` passes 13/13 symlinks
- [x] `zsh -i` starts cleanly; syntax highlighting loaded, `cd` is zoxide's function, `cat` alias and `MANPAGER` set, piped `cat` output stays plain
- [x] `bat --list-themes` shows Catppuccin flavors; sample render uses Mocha palette
- [ ] Live tmux session: confirm window renumbering on window close
- [ ] Fresh-machine path: `git submodule update --init` + `make mac` (not exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)